### PR TITLE
Fix error with trying to pull order without products

### DIFF
--- a/src/Model/Orders/GetNewReceipts/Receipt.php
+++ b/src/Model/Orders/GetNewReceipts/Receipt.php
@@ -88,7 +88,7 @@ class Receipt
             $data['nip'],
             array_map(
                 fn(array $productData) => Product::fromPrimitives($productData),
-                $data['products'],
+                $data['products'] ?? [],
             ),
         );
     }

--- a/src/Model/Orders/GetOrders/Order.php
+++ b/src/Model/Orders/GetOrders/Order.php
@@ -248,7 +248,7 @@ class Order
             $data['pack_state'],
             array_map(
                 fn(array $productData) => OrderProduct::fromPrimitives($productData),
-                $data['products'],
+                $data['products'] ?? [],
             ),
         );
     }


### PR DESCRIPTION
Some orders in BLK can be without products, in this case, we will have an error `Undefined index: products`

In my fix, I have added a safe mode to pull products array